### PR TITLE
GitIgnore für generierte Dateien.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+*.bbl
+*.blg
+*.dvi
+*.synctex.gz
+*.bib
+*.idx
+*.out
+*.toc
 *.aux
 *.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.aux
+*.log
+
+*~
+
+Thumbs.db
+
+*.pdf


### PR DESCRIPTION
Verhindert dass generierten Dateien nicht ausversehen in einem Commit landen.
