### PR TITLE
Klammern bei input für kompatibilität mit TeXstudio

### DIFF
--- a/skript/drehimpuls.tex
+++ b/skript/drehimpuls.tex
@@ -2068,5 +2068,5 @@ der Radialbewegung, w"ahrend der zweite Term die Rotationsenergie ist.
 \rhead{"Ubungsaufgabe}
 \begin{uebungsaufgaben}
 \item
-\input uebungsaufgaben/12001.tex
+\input{uebungsaufgaben/12001.tex}
 \end{uebungsaufgaben}

--- a/skript/einfach.tex
+++ b/skript/einfach.tex
@@ -1028,12 +1028,12 @@ Hamiltonoperator vertauschen.
 \rhead{"Ubungsaufgaben}
 \begin{uebungsaufgaben}
 \item
-\input uebungsaufgaben/02001.tex
+\input{uebungsaufgaben/02001.tex}
 \item
-\input uebungsaufgaben/02002.tex
+\input{uebungsaufgaben/02002.tex}
 \item
-\input uebungsaufgaben/02003.tex
+\input{uebungsaufgaben/02003.tex}
 \item
-\input uebungsaufgaben/02004.tex
+\input{uebungsaufgaben/02004.tex}
 \end{uebungsaufgaben}
 

--- a/skript/hamilton.tex
+++ b/skript/hamilton.tex
@@ -770,10 +770,10 @@ des Drehimuplses zu berechnen.
 \rhead{"Ubungsaufgaben}
 \begin{uebungsaufgaben}
 \item
-\input uebungsaufgaben/05001.tex
+\input{uebungsaufgaben/05001.tex}
 \item
-\input uebungsaufgaben/05002.tex
+\input{uebungsaufgaben/05002.tex}
 \item
-\input uebungsaufgaben/05003.tex
+\input{uebungsaufgaben/05003.tex}
 \end{uebungsaufgaben}
 

--- a/skript/harmonisch.tex
+++ b/skript/harmonisch.tex
@@ -605,8 +605,8 @@ Wellenfunktion gegebenen Wahrscheinlichkeitsdichte $|\psi_n(x)|^2$.
 \rhead{"Ubungsaufgaben}
 \begin{uebungsaufgaben}
 \item
-\input uebungsaufgaben/08001.tex
+\input{uebungsaufgaben/08001.tex}
 \item
-\input uebungsaufgaben/08002.tex
+\input{uebungsaufgaben/08002.tex}
 \end{uebungsaufgaben}
 

--- a/skript/heisenberg.tex
+++ b/skript/heisenberg.tex
@@ -673,9 +673,9 @@ wenn auch nur f"ur kurze Zeit $\Delta t$.
 \rhead{"Ubungsaufgaben}
 \begin{uebungsaufgaben}
 \item
-\input uebungsaufgaben/07001.tex
+\input{uebungsaufgaben/07001.tex}
 \item
-\input uebungsaufgaben/07002.tex
+\input{uebungsaufgaben/07002.tex}
 \item
-\input uebungsaufgaben/07003.tex
+\input{uebungsaufgaben/07003.tex}
 \end{uebungsaufgaben}

--- a/skript/hilbert.tex
+++ b/skript/hilbert.tex
@@ -653,9 +653,9 @@ Die Matrixelemente stimmen "uberein, also ist $A=A'$.
 \rhead{"Ubungsaufgaben}
 \begin{uebungsaufgaben}
 \item
-\input uebungsaufgaben/03001.tex
+\input{uebungsaufgaben/03001.tex}
 \item
-\input uebungsaufgaben/03002.tex
+\input{uebungsaufgaben/03002.tex}
 \item
-\input uebungsaufgaben/03003.tex
+\input{uebungsaufgaben/03003.tex}
 \end{uebungsaufgaben}

--- a/skript/komplex.tex
+++ b/skript/komplex.tex
@@ -1061,16 +1061,16 @@ sondern rein imagin"are Zahlen.
 \rhead{"Ubungsaufgaben}
 \begin{uebungsaufgaben}
 \item
-\input uebungsaufgaben/15001.tex
+\input{uebungsaufgaben/15001.tex}
 \item
-\input uebungsaufgaben/15002.tex
+\input{uebungsaufgaben/15002.tex}
 \item
-\input uebungsaufgaben/15003.tex
+\input{uebungsaufgaben/15003.tex}
 \item
-\input uebungsaufgaben/15004.tex
+\input{uebungsaufgaben/15004.tex}
 \item
-\input uebungsaufgaben/15005.tex
+\input{uebungsaufgaben/15005.tex}
 \item
-\input uebungsaufgaben/15006.tex
+\input{uebungsaufgaben/15006.tex}
 \end{uebungsaufgaben}
 

--- a/skript/quantencomputer.tex
+++ b/skript/quantencomputer.tex
@@ -1196,5 +1196,5 @@ ist also noch ein weiter Weg.
 \rhead{"Ubungsaufgabe}
 \begin{uebungsaufgaben}
 \item
-\input uebungsaufgaben/04001.tex
+\input{uebungsaufgaben/04001.tex}
 \end{uebungsaufgaben}

--- a/skript/quantisierung.tex
+++ b/skript/quantisierung.tex
@@ -358,8 +358,8 @@ Potentialen, um erste Erfahrungen mit der Schr"odingergleichung
 zu sammeln und einen ersten Eindruck von den Eigenheiten der
 des quantenmechanischen Verhaltens von Teilchen zu erhalten.
 
-\input potentialkasten.tex
-\input potentialtopf.tex
+\input{potentialkasten.tex}
+\input{potentialtopf.tex}
 
 \section{Wahrscheinlichkeitsstrom}
 % Kontinuitätsgleichung für die Wahrscheinlichkeitsdichte <psi(x)|psi(x)>
@@ -532,9 +532,9 @@ Kontinuit"atsgleichung
 \rhead{"Ubungsaufgaben}
 \begin{uebungsaufgaben}
 \item
-\input uebungsaufgaben/06001.tex
+\input{uebungsaufgaben/06001.tex}
 \item
-\input uebungsaufgaben/06002.tex
+\input{uebungsaufgaben/06002.tex}
 \end{uebungsaufgaben}
 
 

--- a/skript/skript.tex
+++ b/skript/skript.tex
@@ -212,7 +212,7 @@ Hochschule f"ur Technik, Rapperswil, 2015
 \renewcommand{\qedsymbol}{$\bigcirc$}
 }{\end{proof}}
 
-\input linsys.tex
+\input{linsys.tex}
 \allowdisplaybreaks
 
 \lhead{Inhaltsverzeichnis}
@@ -223,28 +223,28 @@ Hochschule f"ur Technik, Rapperswil, 2015
 \newtheorem{definition}{Definition}[chapter]
 \newtheorem{annahme}{Annahme}[chapter]
 \mainmatter
-\input vorwort.tex
+\input{vorwort.tex}
 \part{Grundlagen}
 %\keineloesungen
 \begin{refsection}
-\input einleitung.tex
-\input einfach.tex
-\input hilbert.tex
-\input quantencomputer.tex
-\input hamilton.tex
-\input quantisierung.tex
-\input heisenberg.tex
-\input harmonisch.tex
-\input h.tex
-\input stoerungstheorie.tex
-\input magnetfeld.tex
-\input drehimpuls.tex
-\input spin.tex
-\input festkoerper.tex
+\input{einleitung.tex}
+\input{einfach.tex}
+\input{hilbert.tex}
+\input{quantencomputer.tex}
+\input{hamilton.tex}
+\input{quantisierung.tex}
+\input{heisenberg.tex}
+\input{harmonisch.tex}
+\input{h.tex}
+\input{stoerungstheorie.tex}
+\input{magnetfeld.tex}
+\input{drehimpuls.tex}
+\input{spin.tex}
+\input{festkoerper.tex}
 \begin{appendices}
-\input komplex.tex
-\input kugelkoordinaten.tex
-\input konstanten.tex
+\input{komplex.tex}
+\input{kugelkoordinaten.tex}
+\input{konstanten.tex}
 \end{appendices}
 \vfill
 \pagebreak
@@ -256,41 +256,41 @@ Hochschule f"ur Technik, Rapperswil, 2015
 
 \part{Anwendungen und Weiterf"uhrende Themen}
 \lhead{Anwendungen}
-\input uebersicht.tex
+\input{uebersicht.tex}
 \def\chapterauthor#1{{\large #1}\bigskip\bigskip}
 % Quanteninformatik
-\input crypto/main.tex
-\input teleport/main.tex
-\input simon/main.tex
+\input{crypto/main.tex}
+\input{teleport/main.tex}
+\input{simon/main.tex}
 % Halbleiterbauelement
-\input tunneldiode/main.tex
-\input flash/main.tex
+\input{tunneldiode/main.tex}
+\input{flash/main.tex}
 % Anwendung der Störungstheorie
-\input atomuhr/main.tex
-\input efeld/main.tex
-\input anharmonisch/main.tex
+\input{atomuhr/main.tex}
+\input{efeld/main.tex}
+\input{anharmonisch/main.tex}
 % Sphärische harmonische Analyse
-\input kugel/main.tex
+\input{kugel/main.tex}
 % Weitere Anwendungen
-\input laser/main.tex
-\input mri/main.tex
+\input{laser/main.tex}
+\input{mri/main.tex}
 % Supraleitung
-\input supraleitung/main.tex
-\input bose/main.tex
-\input heisenberg/main.tex
-%\input stark/main.tex
-\input bell/main.tex
-\input feldquantisierung/main.tex
-%\input rtm/main.tex
-%\input orbitale/main.tex
-%\input franckhertz/main.tex
-%\input maser/main.tex
-%\input quantumdot/main.tex
+\input{supraleitung/main.tex}
+\input{bose/main.tex}
+\input{heisenberg/main.tex}
+%\input{stark/main.tex}
+\input{bell/main.tex}
+\input{feldquantisierung/main.tex}
+%\input{rtm/main.tex}
+%\input{orbitale/main.tex}
+%\input{franckhertz/main.tex}
+%\input{maser/main.tex}
+%\input{quantumdot/main.tex}
 \vfill
 \pagebreak
 \ifodd\value{page}\else\null\clearpage\fi
 \lhead{Index}
 \rhead{}
-\input skript.ind
+\input{skript.ind}
 
 \end{document}

--- a/skript/stoerungstheorie.tex
+++ b/skript/stoerungstheorie.tex
@@ -860,7 +860,7 @@ aufgespalten.
 \rhead{"Ubungsaufgaben}
 \begin{uebungsaufgaben}
 \item
-\input uebungsaufgaben/10001.tex
+\input{uebungsaufgaben/10001.tex}
 \item
-\input uebungsaufgaben/10002.tex
+\input{uebungsaufgaben/10002.tex}
 \end{uebungsaufgaben}

--- a/skript/tunneldiode/main.tex
+++ b/skript/tunneldiode/main.tex
@@ -108,7 +108,7 @@ gelten. Somit haben wir ein Gleichungssystem mit vier Gleichungen f"ur vier Unbe
 %TODO: Überleitung zur Berechnung mit Matrizen
 %      geometrischer Aufbau der Tunneldiode vs. Siliziumdiode
 %	   Rückkehr zur Tunneldiode -> Wie der Tunneleffekt da auftritt
-\input tunneldiode/t.tex
+\input{tunneldiode/t.tex}
 
 
 \printbibliography[heading=subbibliography]


### PR DESCRIPTION
Bei TeXstudio werden bei mir die \input nicht richtig erkannt wenn die Namen nicht in {} geschrieben sind. Ich denke für Latex spielt dies keine Rolle?
