### PR TITLE
Setup csquotes to use american quotation marks

### DIFF
--- a/skript/skript.tex
+++ b/skript/skript.tex
@@ -27,7 +27,7 @@
 \usepackage{tikz}
 \usepackage{placeins}
 \usepackage{subfigure}
-\usepackage{csquotes}
+\usepackage[autostyle=false,english=american]{csquotes}
 \usepackage{float}
 \usepackage{enumitem}
 \usepackage{wasysym}


### PR DESCRIPTION
The _csquotes_ package allows the use of commands, such as `\enquote`, `\textquote` and `\blockquote`. _csquotes_ automatically uses german quotation marks, as babel is setup to use `ngerman`. As parts of the script use the american quotation marks (`` ...  ''), this commit forces _csquotes_ to use the american quotation marks too.
