### PR TITLE
Fixed bug in Makefile

### DIFF
--- a/skript/Makefile
+++ b/skript/Makefile
@@ -1,12 +1,12 @@
 #
-# Makefile zum Skript ueber High Performance Computing
+# Makefile zum Skript ueber Quantenmechanik
 #
 # (c) 2013 Prof Dr Andreas Mueller, Hochschule Rapperswil
 #
 all:	subdirs skript.pdf
 
 subdirs:
-	for d in graphics uebungsaufgaben bell; \
+	for d in graphics uebungsaufgaben bell supraleitung; \
 	do \
 		cd $${d}; make; cd ..; \
 	done


### PR DESCRIPTION
Das Makefile zu Supraleitung wurde aus dem Haupt-Makefile nicht aufgerufen. Damit schlug der Build aufgrund nicht-existierender Grafiken fehl.

Weiter war der Kommentar im Makefile veraltet (HPC statt QM).
