### PR TITLE
Bellsche Ungleichung - (Vielleicht) letzte Änderungen

### DIFF
--- a/skript/bell/main.bib
+++ b/skript/bell/main.bib
@@ -8,7 +8,7 @@
     title = {Can quantum-mechanical description of physical reality be considered complete?},
     journaltitle = {Physical Review},
     year = {1935},
-    month = {Mar},
+    month = mar,
     volume = {47},
     issue = {10},
     pages = {777-780},
@@ -20,7 +20,7 @@
     title = {Discussion of Experimental Proof for the Paradox of Einstein, Rosen, and Podolsky},
     journaltitle = {Phyical Review},
     year = {1957},
-    month = {Nov},
+    month = nov,
     volume = {108},
     issue = {4},
     pages = {1070--1076},
@@ -35,7 +35,7 @@
     issue = {8},
     pages = {696--702},
     year = {1935},
-    month = {Oct},
+    month = oct,
     publisher = {American Physical Society},
 }
 
@@ -45,7 +45,7 @@
     journal = {Mathematical Proceedings of the Cambridge Philosophical Society},
     volume = {31},
     issue = {04},
-    month = {10},
+    month = oct,
     year = {1935},
     issn = {1469-8064},
     pages = {555--563},
@@ -59,10 +59,9 @@
     issue = {2},
     pages = {166--179},
     year = {1952},
-    month = {Jan},
+    month = jan,
     publisher = {American Physical Society},
 }
-
 
 @online{Bell:XkcdEinstein,
 	author = {Randall Munroe},
@@ -93,7 +92,7 @@
     title = {On the Einstein Podolsky Rosen Paradox},
     journaltitle = {Physics},
     year = {1964},
-    month = {Nov},
+    month = nov,
     volume = {1},
     issue = {3},
     pages = {195--200}
@@ -115,7 +114,7 @@
     pages = {863--914},
     numpages = {0},
     year = {1979},
-    month = {Oct},
+    month = oct,
     publisher = {American Physical Society}
 }
 
@@ -127,7 +126,7 @@
     issue = {14},
     pages = {938--841},
     year = {1927},
-    month = {Apr},
+    month = apr,
     publisher = {American Physical Society}
 }
 
@@ -139,7 +138,7 @@
     issue = {23},
     pages = {5039--5043},
     year = {1998},
-    month = {Dec},
+    month = dec,
     publisher = {American Physical Society}
 }
 
@@ -151,7 +150,7 @@
     issue = {6822},
     page = {791--794},
     year = {2001},
-    month = {Feb}
+    month = feb
 }
 
 @article{Bell:Giustina2013,
@@ -162,7 +161,7 @@
     issue = {7448},
     pages = {227-230},
     year = {2013},
-    month = {Mai}
+    month = mai
 }
 
 @article{Bell:Clauser1969,
@@ -173,7 +172,7 @@
     issue = {15},
     pages = {880--884},
     year = {1969},
-    month = {Oct},
+    month = oct,
     publisher = {American Physical Society}
 }
 
@@ -193,7 +192,7 @@
     issue = {7},
     pages = {460--463},
     year = {1981},
-    month = {Aug},
+    month = aug,
     publisher = {American Physical Society},
 }
 
@@ -205,7 +204,7 @@
     issue = {2},
     pages = {91--94},
     year = {1982},
-    month = {Jul},
+    month = jul,
     publisher = {American Physical Society},
 }
 @article{Bell:Aspect1982:2,
@@ -216,7 +215,7 @@
     issue = {25},
     pages = {1804--1807},
     year = {1982},
-    month = {Dec},
+    month = dec,
     publisher = {American Physical Society},
 }
 

--- a/skript/bell/main.tex
+++ b/skript/bell/main.tex
@@ -76,12 +76,8 @@ eine \emph{nicht}-lokale Theorie.
 Eine Masse hat in der Gravitation sofort, ohne zeitliche 
 Verz\"ogerung, einen Einfluss auf andere Massen -- unabh\"angig von der
 r\"aumlichen Distanz zwischen den beiden Massen. 
-In der speziellen Relativit\"atstheorie wurden die Begriffe von Raum und Zeit
-so definiert, dass sich alle Materie und Energie h\"ochstens mit
-Lichtgeschwindigkeit fortbewegen kann. 
-Die allgemeine Relativit\"atstheorie ist eine alternative Formulierung
-der Newtonschen Gravitationstheorie, welche die in der speziellen
-Relativit\"atstheorie geforderte Lokalit\"at erf\"ullt.
+Die Gravitationstheorie konnte jedoch so erweitert werden, dass sie die in der
+speziellen Relativit\"atstheorie geforderte Lokalit\"at erf\"ullt.
 Einstein war sich deshalb sicher, dass sich auch f\"ur die Quantenmechanik eine
 Theorie herleiten l\"asst, in welcher sich jegliche Ereignisse h\"ochstens mit
 Lichtgeschwindigkeit ausbreiten k\"onnen.
@@ -99,8 +95,6 @@ g\"ultig ist und existiert, ob die Messung durchgef\"uhrt wird oder nicht.
 In einem Gespr\"ach mit Abraham Pais verdeutlichte Albert Einstein diese
 Forderung mit dem bekannten Spruch
 \foreignquote{english}{Do you really believe that the moon exists only when you look at it?}\cite{Bell:Pais1979}
-
-
 
 \section{Das Einstein-Podolsky-Rosen Paradoxon\label{section:bell:epr}}
 Das Einstein-Podolsky-Rosen Paradoxon (EPR Paradoxon) ist ein 
@@ -221,7 +215,7 @@ hergeleitet wird der Spin-Operator durch die Pauli-Matrizen
 beschrieben.
 Wie bereits in Abschnitt~\ref{subsection:bell:epr:idee} betrachten 
 wir den Spin in $x$- und $z$-Richtung.
-Die Eigenvektoren der entsprechenden Pauli-Matrizen betragen
+Die Eigenvektoren der entsprechenden Pauli-Matrizen sind
 
 \begin{align}
     |{+}x\rangle &= \frac{1}{\sqrt{2}}\begin{pmatrix} 1\\1 \end{pmatrix}, &
@@ -258,7 +252,7 @@ Zur Notation dieser kombinierten Zust\"ande wird das Tensorprodukt verwendet.
         des Tensorprodukts wird an dieser Stelle verzichtet.}
     \[
         A \otimes B = \begin{pmatrix} 
-        a_1 b_1 & a_2 b_1 \\ a_1 b_2 & a_2 b_2
+        a_1 b_1 & a_1 b_2 \\ a_2 b_1 & a_2 b_2
         \end{pmatrix}.
     \]
 \end{definition}
@@ -903,7 +897,7 @@ via $\text{4p}^2\,^1\text{S}_0$ und $\text{4p}\,\text{4s}\,^1\text{P}_1$
 in den Grundzustand \"ubergehen.
 Dabei werden zwei Photonen mit einer Wellenl\"ange von \SI{551.3}{\nano\meter}
 bzw. \SI{442.7}{\nano\meter} freigesetzt. 
-Da der Drehimpuls des Calcium Atoms $J=0$ betr\"agt, m\"ussen die Photonen
+Da der Drehimpuls des Kalzium Atoms $J=0$ betr\"agt, m\"ussen die Photonen
 eine entgegengesetzte Polarisation haben.
 
 \begin{figure}

--- a/skript/bell/main.tex
+++ b/skript/bell/main.tex
@@ -173,7 +173,7 @@ Paares $+\frac12 - \frac12 = 0$ betr\"agt.
 
 Wenn also bei Detektor $A$ der Spin des Elektrons entlang der $z$-Achse
 gemessen wird und das Messresultat $+z$ ist, so ist sofort klar, dass
-das das Positron bei Detektor $B$ den Spin $-z$ besitzen muss. 
+das Positron bei Detektor $B$ den Spin $-z$ besitzen muss. 
 Ebenso wird, falls bei Detektor $A$ der Spin entlang der $x$-Achse als $+x$
 gemessen wird, das Positron bei Detektor $B$ den Spin $-x$ besitzen.
 
@@ -812,7 +812,7 @@ womit die Quantenmechanik die BCHSH Ungleichung ebenfalls verletzt.
 
 \section{Experimente}
 Zur experimentellen \"Uberpr\"ufung der Bellschen Ungleichung werden meist
-nicht Elektron-Positron-Paare verwendet, sondern
+nicht Elektron-Positron Paare verwendet, sondern
 Photonen mit identischer Polarisation.
 Dabei k\"onnen die Photon entweder vertikal ($+$) oder horizontal
 ($-$) polarisiert sein. 

--- a/skript/bell/main.tex
+++ b/skript/bell/main.tex
@@ -690,10 +690,10 @@ Diese Ungleichung muss, wenn eine Theorie lokaler, verborgener Variablen
 vorliegt, f\"ur alle Richtungen $\vec{a}$, $\vec{b}$ und $\vec{c}$ gelten.
 Betrachten wir als Beispiel die Messrichtungen
 \begin{align*}
-    \vec{a}\cdot\vec{b} = \frac{\pi}{4}, &&
-    \vec{b}\cdot\vec{c} = \frac{\pi}{4} &&
+    \measuredangle(\vec{a},\vec{b}) = \SI{45}{\degree}, &&
+    \measuredangle(\vec{b},\vec{c}) = \SI{45}{\degree} &&
     \text{und} &&
-    \vec{a}\cdot\vec{c} = 0,
+    \measuredangle(\vec{a},\vec{c}) = \SI{90}{\degree},
 \end{align*}
 welche in Abbildung~\ref{fig:bell:orientierung_pi4} dargestellt sind.
 Werden die Erwartungswerte der Quantenmechanik nach 
@@ -792,10 +792,10 @@ umformen k\"onnen.
 Betrachten wir nun die in Abbildung~\ref{fig:bell:orientierung_2}
 abgebildeten Messrichtungen
 \begin{align*}
-    \vec{a}\cdot\vec{b} = \frac{\pi}{4}, && 
-    \vec{b}\cdot\vec{a}' = \frac{\pi}{4} && 
+    \measuredangle(\vec{a},\vec{b}) = \SI{45}{\degree}, && 
+    \measuredangle(\vec{b},\vec{a}') = \SI{45}{\degree} && 
     \text{und} &&
-    \vec{a}'\cdot\vec{b}' = \frac{\pi}{4}.
+    \measuredangle(\vec{a}',\vec{b}') = \SI{45}{\degree}.
 \end{align*}
 \begin{figure}
     \centering

--- a/skript/skript.tex
+++ b/skript/skript.tex
@@ -7,7 +7,7 @@
 \usepackage{etex}
 \usepackage{geometry}
 \geometry{papersize={170mm,240mm},total={140mm,200mm},top=21mm,bindingoffset=10mm}
-\usepackage[ngerman]{babel}
+\usepackage[english,ngerman]{babel}
 \usepackage{times}
 \usepackage{amsmath,amscd}
 \usepackage{amssymb}

--- a/vortraege/bell/presentation.tex
+++ b/vortraege/bell/presentation.tex
@@ -27,6 +27,10 @@
 \end{frame}
 
 \section{Das EPR Gedankenexperiment}
+\begin{frame}{Das EPR Gedankenexperiment}
+    \centering
+    \includegraphics{../../skript/bell/images/experiment_setup.pdf}
+\end{frame}
 \begin{frame}{Forderungen}
     \begin{itemize}
         \item Lokalit\"at
@@ -35,10 +39,6 @@
         \item Korrektheit
         \item Vollst\"andigkeit
     \end{itemize}
-\end{frame}
-\begin{frame}{Das EPR Gedankenexperiment}
-    \centering
-    \includegraphics{../../skript/bell/images/experiment_setup.pdf}
 \end{frame}
 \begin{frame}{Herleitung}
     \begin{itemize}
@@ -74,7 +74,7 @@
 \begin{frame}{Grundlagen}
     \begin{itemize}
         \item Verallgemeinerung auf beliebige Messrichtungen $\vec{a}$, $\vec{b}$
-        \item Messresultate: $A(\vec{a},\lambda)$, $B(\vec{b},\lambda)$ mit
+        \item Messresultate: $A(\vec{a})$, $B(\vec{b})$ mit
                 \[
                     A(\vec{a}) = \begin{cases}
                         +1 & \text{Spin Up} \\
@@ -137,7 +137,7 @@
 \begin{frame}{Bell-Clauser-Horne-Shimony-Holt Ungleichung}
     \begin{itemize}[<+->]
         \item Keine Perfekte Antikorrelation: 
-                $E(\vec{a},\vec{b}) = -1+\delta$
+                $E(\vec{a},\vec{a}) = -1+\delta$
         \item Mittelwert \"uber mehrere Messungen: 
                 $\left|\bar{A}(\vec{a},\lambda)\right| \leq 1$
         \item 4 Messrichtungen:

--- a/vortraege/bell/presentation.tex
+++ b/vortraege/bell/presentation.tex
@@ -123,10 +123,10 @@
             \]
         \item Beispiel:
             \begin{align*}
-                \vec{a}\cdot\vec{b} = \frac{\pi}{4}, &&
-                \vec{b}\cdot\vec{c} = \frac{\pi}{4} &&
-                \text{und} &&
-                \vec{a}\cdot\vec{c} = 0
+                    \measuredangle(\vec{a},\vec{b}) = \SI{45}{\degree}, &&
+                    \measuredangle(\vec{b},\vec{c}) = \SI{45}{\degree} &&
+                    \text{und} &&
+                    \measuredangle(\vec{a},\vec{c}) = \SI{90}{\degree}.
             \end{align*}
         \item Eingesetzt in $E_{QM} = -\cos(\theta_{ab})$:
             \[
@@ -162,10 +162,10 @@
             \]
         \item Beispiel:
             \begin{align*}
-                \vec{a}\cdot\vec{b} = \frac{\pi}{4}, &&
-                \vec{b}\cdot\vec{a}\,' = \frac{\pi}{4} &&
+                \measuredangle(\vec{a},\vec{b}) = \SI{45}{\degree}, && 
+                \measuredangle(\vec{b},\vec{a}') = \SI{45}{\degree} && 
                 \text{und} &&
-                \vec{a}\,'\cdot\vec{b}' = \frac{\pi}{4}
+                \measuredangle(\vec{a}',\vec{b}') = \SI{45}{\degree}.
             \end{align*}
         \item Eingesetzt in $E_{QM} = -\cos(\theta_{ab})$:
             \[


### PR DESCRIPTION
- Präsentation fast fertig
- BibTeX-File korrigiert
- Englisch als sekundäre Sprache von Babel hinzugefügt. Damit wird `\foreignquote[english]{...}` korrekt Englisch getrennt.
